### PR TITLE
Skip message type: TopicRoomMessage and ArchiveRoomMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Unfortunately, there are a number of problems which exist that we are presently 
 
 Of course, please do not assume that this list encompasses *all* of the bugs which you may encounter:
 
-- Messages which are of the type `GuestAccessMessage` or `NotificationMessage` are skipped; only `UserMessage`'s and `PrivateUserMessage`'s are processed.
+- Messages which are of the type `TopicRoomMessage`, `ArchiveRoomMessage`, `GuestAccessMessage` or `NotificationMessage` are skipped; only `UserMessage`'s and `PrivateUserMessage`'s are processed.
 - Verbose mode could be better (i.e., more verbose).
 - The CLI could perhaps become easier and more intuitive.
 - Documentation should be added beyond simple usage.

--- a/lib/hipmost/hipchat/post_repository.rb
+++ b/lib/hipmost/hipchat/post_repository.rb
@@ -27,6 +27,8 @@ module Hipmost
         json.each do |post_obj|
           next if post_obj.key?("NotificationMessage")
           next if post_obj.key?("GuestAccessMessage")
+          next if post_obj.key?("ArchiveRoomMessage")
+          next if post_obj.key?("TopicRoomMessage")          
           post = post_obj["UserMessage"]
           @posts << Post.new(post, @room)
         end


### PR DESCRIPTION
TopicRoomMessage and ArchiveRoomMessage message type need to be skipped otherwise you get the undefined method error during the import, topics and archived state are not handle by mattermost bulk import.

```
/usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/hipchat/post.rb:7:in `initialize': undefined method `[]' for nil:NilClass (NoMethodError)
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/hipchat/post_repository.rb:32:in `new'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/hipchat/post_repository.rb:32:in `block in load'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/hipchat/post_repository.rb:27:in `each'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/hipchat/post_repository.rb:27:in `load'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:76:in `tap'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:76:in `block (2 levels) in save'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:70:in `each'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:70:in `block in save'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:50:in `open'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:50:in `save'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:43:in `import'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost/cmds/room.rb:19:in `run'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/lib/hipmost.rb:12:in `run'
        from /usr/lib64/ruby/gems/2.1.0/gems/hipmost-0.1.0/exe/hipmost:48:in `<top (required)>'
        from /usr/bin/hipmost:23:in `load'
        from /usr/bin/hipmost:23:in `<main>'
```