### PR TITLE
Hotfix for rooms with only one member

### DIFF
--- a/lib/hipmost/hipchat/room.rb
+++ b/lib/hipmost/hipchat/room.rb
@@ -41,7 +41,11 @@ module Hipmost
       end
 
       def users
-        @users ||= attrs["members"].map{|uid| Hipchat.users[uid] }
+        if not attrs["members"].first.is_a? Integer
+          @users ||= [ Hipchat.users[attrs["members"].first["id"]] ]
+        else
+          @users ||= attrs["members"].map{|uid| Hipchat.users[uid] }
+        end
       end
 
       def posts


### PR DESCRIPTION
Rooms with only one member are having a different format in the json object and would result in an error:
```
# hipmost -v public import "site" 'Company':"site"
site
Parsing rooms for Hipchat and Mattermost...
Hipchat room is:               site
Mattermost team & channel are: Company:site
Successfully parsed rooms

Opening /root/migrate/site.jsonl for writing...
Writing version header...
Writing team info...
Writing channel info...
Writing room members...
Traceback (most recent call last):
        14: from /usr/local/rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `<main>'
        13: from /usr/local/rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `eval'
        12: from /usr/local/rvm/gems/ruby-2.5.1/bin/hipmost:23:in `<main>'
        11: from /usr/local/rvm/gems/ruby-2.5.1/bin/hipmost:23:in `load'
        10: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/exe/hipmost:48:in `<top (required)>'
         9: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost.rb:14:in `run'
         8: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:23:in `run'
         7: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:47:in `import'
         6: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:54:in `save'
         5: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:54:in `open'
         4: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:64:in `block in save'
         3: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:64:in `each'
         2: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:65:in `block (2 levels) in save'
         1: from /usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:65:in `each'
/usr/local/rvm/gems/ruby-2.5.1/gems/hipmost-1.0/lib/hipmost/cmds/room.rb:66:in `block (3 levels) in save': undefined method `to_jsonl' for nil:NilClass (NoMethodError)
```

### data/rooms.json
```
 {
    "Room": {
      "created": "2018-06-07T14:57:26+00:00",
      "guest_access_url": null,
      "id": 12,
      "is_archived": false,
      "members": [
        1,
        2,
        3,
        4,
        6
      ],
      "name": "dev",
      "owner": 6,
      "participants": [],
      "privacy": "private",
      "room_admins": [
        6
      ],
      "topic": ""
    }
  },

"Room": {
        "created": "2018-10-06T12:48:40+00:00",
        "guest_access_url": null,
        "id": 14,
        "is_archived": false,
        "members": [
          {
            "id": 1,
            "mention_name": "heuri",
            "name": "heuri",
            "room_roles": [
              "room_member",
              "room_admin"
            ],
            "version": "PCBLOVIS"
          }
        ],
        "name": "Vertrieb",
        "owner": 1,
        "participants": [],
        "privacy": "public",
        "room_admins": [
          1
        ],
        "topic": ""
      }
```